### PR TITLE
Fixed compatibility with Godot 4.0-RC1

### DIFF
--- a/__gdrxsingleton__.gd
+++ b/__gdrxsingleton__.gd
@@ -51,7 +51,7 @@ const THREAD_JOIN_INTERVAL : float = 1.0
 
 ## Dummy class to represent the main [Thread] instance
 class _MainThreadDummy extends Thread:
-	func start(_callable : Callable, _priority : int = 1) -> int:
+	func start(_callable : Callable, _priority : Priority = 1) -> int:
 		GDRx.raise_message("Do not launch the Main Thread Dummy!")
 		return -1
 	func wait_to_finish() -> Variant:

--- a/internal/lock.gd
+++ b/internal/lock.gd
@@ -24,7 +24,7 @@ func unlock():
 	self._semaphore.post()
 
 func try_lock() -> bool:
-	return self._semaphore.try_wait() == OK
+	return self._semaphore.try_wait()
 
 func is_locking_thread() -> bool:
 	var id = OS.get_thread_caller_id()

--- a/internal/rlock.gd
+++ b/internal/rlock.gd
@@ -36,7 +36,7 @@ func unlock():
 	self._mutex.unlock()
 
 func try_lock() -> bool:
-	return self._mutex.try_lock() == OK
+	return self._mutex.try_lock()
 
 func is_locking_thread() -> bool:
 	var id = OS.get_thread_caller_id()


### PR DESCRIPTION
This PR fixes a couple of small issues and type incompatibilities that made the library unusable in beta17 and RC1 (at least on Windows 11 and Android)