### PR TITLE
Fixed compatibility with v4.0-rc3

### DIFF
--- a/__gdrxsingleton__.gd
+++ b/__gdrxsingleton__.gd
@@ -52,7 +52,7 @@ const THREAD_JOIN_INTERVAL : float = 1.0
 ## Dummy class to represent the main [Thread] instance
 class _MainThreadDummy extends Thread:
 	@warning_ignore("native_method_override")
-	func start(_callable : Callable, _priority : Priority = 1) -> int:
+	func start(_callable : Callable, _priority : Priority = 1) -> Error:
 		GDRx.raise_message("Do not launch the Main Thread Dummy!")
 		return -1
 	@warning_ignore("native_method_override")

--- a/engine/observable/reactiveproperty/reactivecollection.gd
+++ b/engine/observable/reactiveproperty/reactivecollection.gd
@@ -59,7 +59,7 @@ func _init(collection = []):
 	elif collection is IterableBase:
 		var it = collection.iter()
 		var item = it.next()
-		while not item is it.End:
+		while not is_instance_of(item, it.End):
 			super.add_item(item)
 	
 	self._observe_add = Observable.new(self._get_subscription(CollectionAddEvent))

--- a/internal/basic.gd
+++ b/internal/basic.gd
@@ -36,4 +36,4 @@ func default_factory(__ : SchedulerBase) -> Observable:
 func default_type_equality(type, value) -> bool:
 	if type is Dictionary:
 		return typeof(value) == TYPE_INT and type.find_key(value) != null
-	return typeof(value) == type if type is int else value is type
+	return typeof(value) == type if is_instance_of(type, TYPE_INT) else is_instance_of(value, type)

--- a/internal/utils.gd
+++ b/internal/utils.gd
@@ -3,7 +3,7 @@ const MAX_SIZE = 9223372036854775807
 ## Represents an un-defined state
 class NotSet extends Comparable:
 	func eq(other) -> bool:
-		return other is self
+		return is_instance_of(other, self)
 
 ## An infinite iterable sequence
 class InfiniteIterator extends IterableBase:
@@ -14,7 +14,7 @@ class InfiniteIterator extends IterableBase:
 		self._counter = 0
 	func next() -> Variant:
 		self._counter += 1
-		if not self._infval is GDRx.util.NotSet:
+		if not is_instance_of(self._infval, GDRx.util.NotSet):
 			return self._infval
 		return self._counter
 	func iter() -> Iterator:

--- a/observable/catch.gd
+++ b/observable/catch.gd
@@ -44,7 +44,7 @@ static func catch_with_iterable_(sources : IterableBase) -> Observable:
 			) \
 			.end_try_catch():
 				pass
-			elif current.v is sources_.End:
+			elif is_instance_of(current.v, sources_.End):
 				if last_exception.v != null:
 					observer.on_error(last_exception.v)
 				else:

--- a/observable/concat.gd
+++ b/observable/concat.gd
@@ -25,7 +25,7 @@ static func concat_with_iterable_(sources : IterableBase) -> Observable:
 			) \
 			.end_try_catch():
 				pass
-			elif current.v is sources_.End:
+			elif is_instance_of(current.v, sources_.End):
 				observer.on_completed()
 			else:
 				var d = SingleAssignmentDisposable.new()

--- a/observable/onerrorresumenext.gd
+++ b/observable/onerrorresumenext.gd
@@ -31,7 +31,7 @@ static func on_error_resume_next_(
 			action_ : Callable = func(__, ___, ____): return
 		):
 			var source = sources_.next()
-			if source is sources_.End:
+			if is_instance_of(source, sources_.End):
 				observer.on_completed()
 				return
 			

--- a/observable/range.gd
+++ b/observable/range.gd
@@ -63,7 +63,7 @@ static func range_(
 		):
 			if GDRx.assert_(iterator != null): return
 			var item = iterator.next()
-			if item is iterator.End:
+			if is_instance_of(item, iterator.End):
 				observer.on_completed()
 			else:
 				observer.on_next(item)

--- a/operators/_reduce.gd
+++ b/operators/_reduce.gd
@@ -23,7 +23,7 @@ static func reduce_(
 #		an observable sequence containing a single element with the
 #		final accumulator value.
 #	"""
-	if !(seed_ is GDRx.util.NotSet):
+	if !is_instance_of(seed_, GDRx.util.NotSet):
 		var _seed = seed_
 		var scanner = GDRx.op.scan(accumulator, _seed)
 		return GDRx.pipe.compose2(

--- a/operators/_scan.gd
+++ b/operators/_scan.gd
@@ -2,7 +2,7 @@ static func scan_(
 	accumulator : Callable,
 	seed_ = GDRx.util.GetNotSet()
 ) -> Callable:
-	var has_seed = !(seed_ is GDRx.util.NotSet)
+	var has_seed = !is_instance_of(seed_, GDRx.util.NotSet)
 	
 	var scan = func(source : Observable) -> Observable:
 #		"""Partially applied scan operator.

--- a/operators/_zip.gd
+++ b/operators/_zip.gd
@@ -48,7 +48,7 @@ static func zip_with_iterable_(seq : IterableBase) -> Callable:
 			
 			var on_next = func(left):
 				var right = second.next()
-				if right is second.End:
+				if is_instance_of(right, second.End):
 					observer.on_completed()
 				else:
 					var result = Tuple.new([left, right])

--- a/pipe.gd
+++ b/pipe.gd
@@ -1,7 +1,7 @@
 func reduce(fun : Callable, it : IterableBase, initial = GDRx.util.GetNotSet()):
 	var next_ = it.next()
 	var value_ = initial
-	while not next_ is it.End:
+	while not is_instance_of(next_, it.End):
 		value_ = fun.call(value_, next_)
 		next_ = it.next()
 	return value_


### PR DESCRIPTION
Last RC release had a breaking change in how the `is` operator works (see: https://github.com/godotengine/godot/pull/73489 )

I changed all the instances of `is` to `is_instance_of()`, however a proper review is required to see if all the cases are correct in the context of GodotRx.