### PR TITLE
Fix array assignment in with_latest_from

### DIFF
--- a/addons/reactivex/observable/withlatestfrom.gd
+++ b/addons/reactivex/observable/withlatestfrom.gd
@@ -49,7 +49,8 @@ static func with_latest_from_(
 			)
 			parent_subscription.disposable = disp
 			
-			var ret : Array[SingleAssignmentDisposable] = children_subscription.duplicate()
+			var ret : Array[SingleAssignmentDisposable] = []
+			ret.assign(children_subscription.duplicate())
 			ret.push_front(parent_subscription)
 			return ret
 		


### PR DESCRIPTION
The existing code triggers this error:

    Trying to assign an array of type "Array" to a variable of type "Array[SingleAssignmentDisposable]".